### PR TITLE
Move Fallback to Steps struct

### DIFF
--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -205,11 +205,11 @@ func TestCleanupHooks(t *testing.T) {
 					executionOrder = append(executionOrder, "exec")
 					return nil, errors.New("exec failed")
 				},
+				Fallback: func(ctx context.Context, prepResult any, err error) (any, error) {
+					executionOrder = append(executionOrder, "fallback")
+					return "fallback result", nil
+				},
 			},
-			pocket.WithFallback(func(ctx context.Context, input any, err error) (any, error) {
-				executionOrder = append(executionOrder, "fallback")
-				return "fallback result", nil
-			}),
 			pocket.WithOnSuccess(func(ctx context.Context, store pocket.StoreWriter, output any) {
 				executionOrder = append(executionOrder, "onSuccess")
 			}),


### PR DESCRIPTION
## Summary
- Moved Fallback from a separate option to the Steps struct
- Fallback now receives prepResult instead of original input for consistency with Exec
- Removed WithFallback function entirely (no deprecation needed as project hasn't launched)

## Changes
1. **Added FallbackFunc type** - New function type with signature: `func(ctx context.Context, prepResult any, execErr error) (fallbackResult any, err error)`
2. **Updated Steps struct** - Added Fallback field alongside Prep, Exec, and Post
3. **Updated NewNode** - Handles Steps.Fallback by converting to internal nodeOptions format  
4. **Updated graph execution** - Passes prepResult to fallback (not original input)
5. **Removed WithFallback** - Completely removed the option function
6. **Updated tests** - All tests now use Steps.Fallback
7. **Updated documentation** - CLAUDE.md reflects the new structure

## Rationale
Since all fields in Steps are optional (Prep, Exec, Post), it makes sense to include Fallback there as well. This provides a more consistent API where all lifecycle functions are grouped together.

The change to pass prepResult instead of original input makes the data flow more consistent:
- Input → Prep → prepResult → (Exec OR Fallback) → Post

## Test plan
All existing tests pass ✓

🤖 Generated with [Claude Code](https://claude.ai/code)